### PR TITLE
Add hash routing demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-test
+# Hash Routing Demo
+
+This repository contains a minimal static website that demonstrates client-side routing using URL fragments.
+It is designed for quick testing of how hash-based routes behave when embedded in other tools, such as
+PowerPoint.
+
+## Routes
+
+- `#/` — Home
+- `#/about` — About page
+- `#/contact` — Contact page
+
+## Usage
+
+Open `index.html` in a browser or host it on any static server. The page listens for changes to
+`window.location.hash` and swaps in a bit of placeholder content for each route so you can see the routing in action.
+
+## Deploying to GitHub Pages
+
+1. Push this repository to GitHub.
+2. In the repository settings, enable **GitHub Pages** from the `main` branch.
+3. After a few minutes your site will be available at:
+
+```
+https://<username>.github.io/<repository-name>/
+```
+
+You can then test the routes at:
+
+```
+https://<username>.github.io/<repository-name>/#/
+https://<username>.github.io/<repository-name>/#/about
+https://<username>.github.io/<repository-name>/#/contact
+```
+
+This simple setup should preserve the fragment portion of the URL when opened from other applications.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hash Routing Demo</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; }
+    nav a { margin-right: 1em; }
+  </style>
+  <script>
+    function render() {
+      const content = document.getElementById('content');
+      const hash = window.location.hash;
+      if (hash === '#/about') {
+        content.innerHTML = '<h1>About</h1><p>This is some placeholder text for the about page.</p>';
+      } else if (hash === '#/contact') {
+        content.innerHTML = '<h1>Contact</h1><p>Here\'s some dummy info for getting in touch.</p>';
+      } else {
+        content.innerHTML = '<h1>Home</h1><p>Welcome to the home page! Replace this with your own content.</p>';
+      }
+    }
+    window.addEventListener('hashchange', render);
+    window.addEventListener('DOMContentLoaded', render);
+  </script>
+</head>
+<body>
+  <nav>
+    <a href="#/">Home</a> |
+    <a href="#/about">About</a> |
+    <a href="#/contact">Contact</a>
+  </nav>
+  <div id="content"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with simple fragment-based routing
- document usage and GitHub Pages deployment steps
- expand each route with placeholder text to show routing works

## Testing
- `python3 -m http.server 8999` (responded with HTTP 200)
- `curl -I http://localhost:8999` (verified server response)

------
https://chatgpt.com/codex/tasks/task_e_684888b3b6d88321b4427a2fa3de8ceb